### PR TITLE
Break retain cycle by making the CocoaMQTT delegate a weak property

### DIFF
--- a/CocoaMQTT/CocoaMQTT.swift
+++ b/CocoaMQTT/CocoaMQTT.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * MQTT Delegate
  */
-protocol CocoaMQTTDelegate {
+protocol CocoaMQTTDelegate : class {
 
     /**
      * MQTT connected with server
@@ -166,7 +166,7 @@ class CocoaMQTT: NSObject, CocoaMQTTClient, GCDAsyncSocketDelegate, CocoaMQTTRea
 
     //delegate
 
-    var delegate: CocoaMQTTDelegate?
+    weak var  delegate: CocoaMQTTDelegate?
 
     //socket and connection
 


### PR DESCRIPTION
CocoaMQTT was retaining its delegate, causing a retain cycle when the delegate is the owner of the CocoaMQTT instance. Here, we break that cycle by making the delegate an unretained (weak) property. This has the side effect of requiring the CocoaMQTTDelegate protocol to be implemented by a class (not a struct or enum for example), so we mark the CocoaMQTTDelegate as such.
